### PR TITLE
Add devise.user_registrations.signed_up Japanese

### DIFF
--- a/config/locales/ja/ja.yml
+++ b/config/locales/ja/ja.yml
@@ -391,6 +391,9 @@ ja:
   depth: "奥行き"
   description: "説明"
   destroy: "破壊する"
+  devise:
+    user_registrations:
+      signed_up: "ユーザー登録が完了しました。"  
   didnt_receive_confirmation_instructions: "アカウントの登録方法の説明を受け取っていませんか？"
   didnt_receive_unlock_instructions: "アカウントの凍結解除方法の説明を受け取っていませんか？"
   discount_amount: "割引額"


### PR DESCRIPTION
"signed_up" translation is included in 2.0 or hight branch. Please add it to 1.3 branch.
