### PR TITLE
Add exceeds_available_stock of Japanese translation

### DIFF
--- a/config/locales/ja/ja.yml
+++ b/config/locales/ja/ja.yml
@@ -18,6 +18,8 @@ ja:
   active: "有効"
   activerecord:
     attributes:
+      line_items:
+        quantity: "数量"
       spree/address:
         address1: "住所1"
         address2: "住所2"
@@ -1186,6 +1188,7 @@ ja:
     is_too_large: "要求された量は在庫を超えています。"
     must_be_int: "整数であることが必要です"
     must_be_non_negative: "0以上の数字が必要です"
+    exceeds_available_stock: "は、在庫以上の値が指定されています。在庫数以下の数を指定してください。"
   value: "値"
   variant: "種類"
   variants: "種類"


### PR DESCRIPTION
I do not know the reason why line_items is needed to translate a quantity.But if it does not exist, it has never been translated.
<img width="510" alt="2015-10-23 17 21 48 2" src="https://cloud.githubusercontent.com/assets/3713713/10720160/6cb34344-7bd7-11e5-8a35-8de4c73dc6aa.png">
