### PR TITLE
Add unlock_token japanese

### DIFF
--- a/config/locales/ja/ja.yml
+++ b/config/locales/ja/ja.yml
@@ -130,6 +130,7 @@ ja:
         email: "Eメール"
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
+        unlock_token: "凍結解除コード"
       spree/variant:
         cost_price: "原価"
         depth: "奥行き"


### PR DESCRIPTION
https://github.com/degica/extinguisher/pull/554 uses this.

"凍結解除" as the translation of unlock is used in [devise_i18n](https://github.com/tigrish/devise-i18n/blob/master/rails/locales/ja.yml#L22). 
